### PR TITLE
Differ heading levels

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -37,11 +37,46 @@ repository:
           '3': {name: punctuation.definition.markdown}
         name: markup.fenced_code.block.markdown
       heading:
-        begin: (?:^|\G)[ ]{0,3}(#{1,6})\s*(?=[\S[^#]])
+        match: (?:^|\G)[ ]{0,3}((#{1,6})\s*(?=[\S[^#]]).*?\s*(#{1,6})?)$\n?
         captures:
-          '1': {name: punctuation.definition.heading.markdown}
-        contentName: entity.name.section.markdown
-        end: \s*(#{1,6})?$\n?
+          '1':
+            patterns:
+            - match: (#{6})\s*(?=[\S[^#]])(.*?)\s*(\s+#+)?$\n?
+              name: 'heading.6.markdown'
+              captures:
+                '1': {name: punctuation.definition.heading.markdown}
+                '2': {name: entity.name.section.markdown}
+                '3': {name: punctuation.definition.heading.markdown}
+            - match: (#{5})\s*(?=[\S[^#]])(.*?)\s*(\s+#+)?$\n?
+              name: 'heading.5.markdown'
+              captures:
+                '1': {name: punctuation.definition.heading.markdown}
+                '2': {name: entity.name.section.markdown}
+                '3': {name: punctuation.definition.heading.markdown}
+            - match: (#{4})\s*(?=[\S[^#]])(.*?)\s*(\s+#+)?$\n?
+              name: 'heading.4.markdown'
+              captures:
+                '1': {name: punctuation.definition.heading.markdown}
+                '2': {name: entity.name.section.markdown}
+                '3': {name: punctuation.definition.heading.markdown}
+            - match: (#{3})\s*(?=[\S[^#]])(.*?)\s*(\s+#+)?$\n?
+              name: 'heading.3.markdown'
+              captures:
+                '1': {name: punctuation.definition.heading.markdown}
+                '2': {name: entity.name.section.markdown}
+                '3': {name: punctuation.definition.heading.markdown}
+            - match: (#{2})\s*(?=[\S[^#]])(.*?)\s*(\s+#+)?$\n?
+              name: 'heading.2.markdown'
+              captures:
+                '1': {name: punctuation.definition.heading.markdown}
+                '2': {name: entity.name.section.markdown}
+                '3': {name: punctuation.definition.heading.markdown}
+            - match: (#{1})\s*(?=[\S[^#]])(.*?)\s*(\s+#+)?$\n?
+              name: 'heading.1.markdown'
+              captures:
+                '1': {name: punctuation.definition.heading.markdown}
+                '2': {name: entity.name.section.markdown}
+                '3': {name: punctuation.definition.heading.markdown}
         name: markup.heading.markdown
         patterns:
         - {include: '#inline'}


### PR DESCRIPTION
Fixes Microsoft/vscode#47113

Spans the entire line, so it's possible to have both:
![one](https://user-images.githubusercontent.com/9638156/38458200-28f91690-3aa4-11e8-87e1-b21d04d8c47c.png) ![two](https://user-images.githubusercontent.com/9638156/38458202-2d2c64d8-3aa4-11e8-8860-2f2d4b5e5259.png)

Kind of tries to reflect how it will be rendered:

Before             |  After
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/9638156/38458231-88ca1aa6-3aa4-11e8-8fcf-87f285240d0a.png)  | ![after](https://user-images.githubusercontent.com/9638156/38458236-93aed7ea-3aa4-11e8-873d-30ab2513f1c2.png)
 _ | ![comply_with_render](https://user-images.githubusercontent.com/9638156/38458248-c05c69c4-3aa4-11e8-9455-43265c7d8898.gif)

Example:
```json
{
    "scope": "markup.heading.markdown punctuation.definition.heading.markdown",
    "settings": {
        "foreground": "#8a8888",
    }
},
{
    "scope": "heading.1.markdown entity.name.section",
    "settings": {
        "foreground": "#4d85c3",
    }
},
{
    "scope": "heading.2.markdown entity.name.section",
    "settings": {
        "foreground": "#389674",
    }
},
{
    "scope": "heading.3.markdown entity.name.section",
    "settings": {
        "foreground": "#b0be1e",
    }
},
{
    "scope": "heading.4.markdown entity.name.section",
    "settings": {
        "foreground": "#8594c8",
    }
},
{
    "scope": "heading.5.markdown entity.name.section",
    "settings": {
        "foreground": "#f76328",
    }
},
{
    "scope": "heading.6.markdown entity.name.section",
    "settings": {
        "foreground": "#fccf3e",
    }
},
```