### PR TITLE
rename jade to pug

### DIFF
--- a/build.js
+++ b/build.js
@@ -35,7 +35,7 @@ const languages = [
 	{ name: 'git_rebase', identifiers: ['git-rebase-todo'], source: 'text.git-rebase' },
 	{ name: 'go', language: 'go', identifiers: ['go', 'golang'], source: 'source.go' },
 	{ name: 'groovy', language: 'groovy', identifiers: ['groovy', 'gvy'], source: 'source.groovy' },
-	{ name: 'jade', language: 'jade', identifiers: ['jade', 'pug'], source: 'text.jade' },
+	{ name: 'pug', language: 'pug', identifiers: ['jade', 'pug'], source: 'text.pug' },
 
 	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs'], source: 'source.js' },
 	{ name: 'js_regexp', identifiers: ['regexp'], source: 'source.js.regexp' },

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -152,7 +152,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#fenced_code_block_jade</string>
+            <string>#fenced_code_block_pug</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1655,7 +1655,7 @@
               </dict>
             </array>
           </dict>
-          <key>fenced_code_block_jade</key>
+          <key>fenced_code_block_pug</key>
           <dict>
             <key>begin</key>
             <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)(\s+[^`~]*)?$)</string>
@@ -1697,12 +1697,12 @@
                 <key>while</key>
                 <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
                 <key>contentName</key>
-                <string>meta.embedded.block.jade</string>
+                <string>meta.embedded.block.pug</string>
                 <key>patterns</key>
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>text.jade</string>
+                    <string>text.pug</string>
                   </dict>
                 </array>
               </dict>


### PR DESCRIPTION
In Microsoft/vscode#50086 I switched to a new pug grammar (scope `source.pug`).
The language id remains `jade` (I reverted that change, too many external extensions depend on the jade id)