### PR TITLE
Fix YAML frontmatter syntax highlighting when using block literals

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -180,7 +180,7 @@ repository:
     contentName: meta.embedded.block.frontmatter
     patterns:
     - {include: source.yaml}
-    while: ^(?!(-{3}|\.{3})\s*$)
+    end: (^|\G)-{3}|\.{3}\s*$"
   inline:
     patterns:
     - {include: '#ampersand'}

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3294,8 +3294,8 @@
             <string>source.yaml</string>
           </dict>
         </array>
-        <key>while</key>
-        <string>^(?!(-{3}|\.{3})\s*$)</string>
+        <key>end</key>
+        <string>(^|\G)-{3}|\.{3}\s*$"</string>
       </dict>
       <key>inline</key>
       <dict>


### PR DESCRIPTION

![2018-10-05_18-11-50](https://user-images.githubusercontent.com/1630038/46546799-6fd55100-c8ca-11e8-8fd3-c18c87b1c33e.png)


Fixes https://github.com/Microsoft/vscode/issues/59667