### PR TITLE
Markdown: Fix capture keys for link-ref-shortcut

### DIFF
--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -4006,7 +4006,7 @@
                 <key>name</key>
                 <string>string.other.link.title.markdown</string>
               </dict>
-              <key>4</key>
+              <key>3</key>
               <dict>
                 <key>name</key>
                 <string>punctuation.definition.string.end.markdown</string>


### PR DESCRIPTION
Fixes captures for link-ref-shortcut, as described [here](https://github.com/Microsoft/vscode/pull/60698).
It was searching for a fourth key even though there are only three capture groups.

Might be related to [this issue](https://github.com/Microsoft/vscode-markdown-tm-grammar/issues/34) too.