### PR TITLE
Add jsonc, aka json with comments, as a language identifier.

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,6 +40,7 @@ const languages = [
 	{ name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs'], source: 'source.js' },
 	{ name: 'js_regexp', identifiers: ['regexp'], source: 'source.js.regexp' },
 	{ name: 'json', language: 'json', identifiers: ['json', 'json5', 'sublime-settings', 'sublime-menu', 'sublime-keymap', 'sublime-mousemap', 'sublime-theme', 'sublime-build', 'sublime-project', 'sublime-completions'], source: 'source.json' },
+	{ name: 'jsonc', language: 'jsonc', identifiers: ['jsonc'], source: 'source.json.comments' },
 	{ name: 'less', language: 'less', identifiers: ['less'], source: 'source.css.less' },
 	{ name: 'objc', language: 'objc', identifiers: ['objectivec', 'objective-c', 'mm', 'objc', 'obj-c', 'm', 'h'], source: 'source.objc' },
 	{ name: 'scss', language: 'scss', identifiers: ['scss'], source: 'source.css.scss' },

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -168,6 +168,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#fenced_code_block_jsonc</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#fenced_code_block_less</string>
           </dict>
           <dict>
@@ -1870,6 +1874,59 @@
                   <dict>
                     <key>include</key>
                     <string>source.json</string>
+                  </dict>
+                </array>
+              </dict>
+            </array>
+          </dict>
+          <key>fenced_code_block_jsonc</key>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)(\s+[^`~]*)?$)</string>
+            <key>name</key>
+            <string>markup.fenced_code.block.markdown</string>
+            <key>end</key>
+            <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.markdown</string>
+              </dict>
+              <key>5</key>
+              <dict>
+                <key>name</key>
+                <string>fenced_code.block.language</string>
+              </dict>
+              <key>6</key>
+              <dict>
+                <key>name</key>
+                <string>fenced_code.block.language.attributes</string>
+              </dict>
+            </dict>
+            <key>endCaptures</key>
+            <dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.markdown</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>begin</key>
+                <string>(^|\G)(\s*)(.*)</string>
+                <key>while</key>
+                <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+                <key>contentName</key>
+                <string>meta.embedded.block.jsonc</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.json.comments</string>
                   </dict>
                 </array>
               </dict>


### PR DESCRIPTION
Resolves #37. I wasn't able to test it on an actual build of VS Code since there are no instructions on how to do that, but I'm pretty sure it should work from what I understand of the codebase.

Maybe also worth looking at for comparison?: https://github.com/github/linguist/pull/4171