### PR TITLE
Allow chars other than alphanumeric/underscore in link ref definitions

### DIFF
--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3196,7 +3196,7 @@
             <key>match</key>
             <string>(?x)
   \s*            # Leading whitespace
-  (\[)([\w ]+?)(\])(:)    # Reference name
+  (\[)([^]]+?)(\])(:)    # Reference name
   [ \t]*          # Optional whitespace
   (&lt;?)(\S+?)(&gt;?)      # The url
   [ \t]*          # Optional whitespace


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-markdown-tm-grammar/issues/39