### PR TITLE
Relax highlighting rules on HTML element names

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -97,7 +97,7 @@ repository:
     - begin: (?i)(^|\G)\s*(?=<(script|style|pre)(\s|$|>)(?!.*?</(script|style|pre)>))
       end: (?i)(.*)((</)(script|style|pre)(>))
       endCaptures:
-        '1': { patterns: [ {include: text.html.basic} ]}
+        '1': { patterns: [ {include: text.html.derivative} ]}
         '2': {name: meta.tag.structure.$4.end.html}
         '3': {name: punctuation.definition.tag.begin.html}
         '4': {name: entity.name.tag.html}
@@ -105,15 +105,15 @@ repository:
       patterns:
       - begin: (\s*|$)
         patterns:
-        - {include: text.html.basic}
+        - {include: text.html.derivative}
         while: (?i)^(?!.*</(script|style|pre)>)
-    - begin: (?i)(^|\G)\s*(?=</?(address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(\s|$|/?>))
+    - begin: (?i)(^|\G)\s*(?=</?[a-zA-Z]+[^\s/&gt;]*(\s|$|/?>))
       patterns:
-      - {include: text.html.basic}
+      - {include: text.html.derivative}
       while: ^(?!\s*$)
     - begin: (^|\G)\s*(?=(<[a-zA-Z0-9\-](/?>|\s.*?>)|</[a-zA-Z0-9\-]>)\s*$)
       patterns:
-      - {include: text.html.basic}
+      - {include: text.html.derivative}
       while: ^(?!\s*$)
   link-def:
     captures:
@@ -149,7 +149,7 @@ repository:
     name: meta.paragraph.markdown
     patterns:
     - {include: '#inline'}
-    - {include: text.html.basic}
+    - {include: text.html.derivative}
     - {include: '#heading-setext'}
     while: (^|\G)(?!\s*$|#|[ ]{0,3}([-*_>][ ]{2,}){3,}[ \t]*$\n?|[ ]{0,3}[*+->]|[
       ]{0,3}[0-9]+\.)
@@ -177,7 +177,7 @@ repository:
     name: meta.paragraph.markdown
     patterns:
     - {include: '#inline'}
-    - {include: text.html.basic}
+    - {include: text.html.derivative}
     - {include: '#heading-setext'}
     while: (^|\G)((?=\s*[-=]{3,}\s*$)|[ ]{4,}(?=\S))
   raw_block: {begin: '(^|\G)([ ]{4}|\t)', name: markup.raw.block.markdown, while: '(^|\G)([
@@ -260,7 +260,7 @@ repository:
       begin: (?=<[^>]*?>)
       end: (?<=>)
       patterns:
-      - {include: text.html.basic}
+      - {include: text.html.derivative}
     - {include: '#escape'}
     - {include: '#ampersand'}
     - {include: '#bracket'}
@@ -372,7 +372,7 @@ repository:
       begin: (?=<[^>]*?>)
       end: (?<=>)
       patterns:
-      - {include: text.html.basic}
+      - {include: text.html.derivative}
     - {include: '#escape'}
     - {include: '#ampersand'}
     - {include: '#bracket'}

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -192,7 +192,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>text.html.basic</string>
+                <string>text.html.derivative</string>
               </dict>
             </array>
           </dict>
@@ -616,7 +616,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>text.html.basic</string>
+                <string>text.html.derivative</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -3152,7 +3152,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>text.html.basic</string>
+                    <string>text.html.derivative</string>
                   </dict>
                 </array>
               </dict>
@@ -3186,7 +3186,7 @@
                 <array>
                   <dict>
                     <key>include</key>
-                    <string>text.html.basic</string>
+                    <string>text.html.derivative</string>
                   </dict>
                 </array>
                 <key>while</key>
@@ -3196,12 +3196,12 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>(?i)(^|\G)\s*(?=&lt;/?(address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(\s|$|/?&gt;))</string>
+            <string>(?i)(^|\G)\s*(?=&lt;/?[a-zA-Z]+[^\s/&gt;]*(\s|$|/?&gt;))</string>
             <key>patterns</key>
             <array>
               <dict>
                 <key>include</key>
-                <string>text.html.basic</string>
+                <string>text.html.derivative</string>
               </dict>
             </array>
             <key>while</key>
@@ -3214,7 +3214,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>text.html.basic</string>
+                <string>text.html.derivative</string>
               </dict>
             </array>
             <key>while</key>
@@ -3323,7 +3323,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>text.html.basic</string>
+            <string>text.html.derivative</string>
           </dict>
           <dict>
             <key>include</key>
@@ -3409,7 +3409,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>text.html.basic</string>
+            <string>text.html.derivative</string>
           </dict>
           <dict>
             <key>include</key>
@@ -3589,7 +3589,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>text.html.basic</string>
+                <string>text.html.derivative</string>
               </dict>
             </array>
           </dict>
@@ -3868,7 +3868,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>text.html.basic</string>
+                <string>text.html.derivative</string>
               </dict>
             </array>
           </dict>

--- a/test/colorize-fixtures/issue-53.md
+++ b/test/colorize-fixtures/issue-53.md
@@ -1,0 +1,5 @@
+<StackLayout orientation="vertical">PascalCase</StackLayout>
+
+<WelcomeMessage greetingText="hi" />
+
+text <RainbowAnimate>PascalCase</RainbowAnimate> text

--- a/test/colorize-results/issue-42_md.json
+++ b/test/colorize-results/issue-42_md.json
@@ -221,13 +221,13 @@
 	},
 	{
 		"c": "Sequence",
-		"t": "text.html.markdown markup.fenced_code.block.markdown",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.swift meta.definition.function.swift meta.generic-parameter-clause.swift meta.generic-parameter-constraint.swift entity.other.inherited-class.swift meta.type-name.swift support.type.swift",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
+			"dark_plus": "support.type: #4EC9B0",
+			"light_plus": "support.type: #267F99",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "support.type: #4EC9B0"
 		}
 	},
 	{
@@ -617,13 +617,13 @@
 	},
 	{
 		"c": "=",
-		"t": "text.html.markdown markup.fenced_code.block.markdown",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.swift keyword.operator.custom.infix.swift",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
 	{
@@ -826,13 +826,13 @@
 	},
 	{
 		"c": "+=",
-		"t": "text.html.markdown markup.fenced_code.block.markdown",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.swift keyword.operator.custom.infix.swift",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
 	{

--- a/test/colorize-results/issue-42_md.json
+++ b/test/colorize-results/issue-42_md.json
@@ -221,13 +221,13 @@
 	},
 	{
 		"c": "Sequence",
-		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.swift meta.definition.function.swift meta.generic-parameter-clause.swift meta.generic-parameter-constraint.swift entity.other.inherited-class.swift meta.type-name.swift support.type.swift",
+		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": "support.type: #4EC9B0",
-			"light_plus": "support.type: #267F99",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "support.type: #4EC9B0"
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
@@ -617,13 +617,13 @@
 	},
 	{
 		"c": "=",
-		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.swift keyword.operator.custom.infix.swift",
+		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": "keyword.operator: #D4D4D4",
-			"light_plus": "keyword.operator: #000000",
-			"dark_vs": "keyword.operator: #D4D4D4",
-			"light_vs": "keyword.operator: #000000",
-			"hc_black": "keyword.operator: #D4D4D4"
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
@@ -826,13 +826,13 @@
 	},
 	{
 		"c": "+=",
-		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.swift keyword.operator.custom.infix.swift",
+		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": "keyword.operator: #D4D4D4",
-			"light_plus": "keyword.operator: #000000",
-			"dark_vs": "keyword.operator: #D4D4D4",
-			"light_vs": "keyword.operator: #000000",
-			"hc_black": "keyword.operator: #D4D4D4"
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{

--- a/test/colorize-results/issue-53_md.json
+++ b/test/colorize-results/issue-53_md.json
@@ -1,0 +1,343 @@
+[
+	{
+		"c": "<",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "StackLayout",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "orientation",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.orientation.html entity.other.attribute-name.html",
+		"r": {
+			"dark_plus": "entity.other.attribute-name: #9CDCFE",
+			"light_plus": "entity.other.attribute-name: #FF0000",
+			"dark_vs": "entity.other.attribute-name: #9CDCFE",
+			"light_vs": "entity.other.attribute-name: #FF0000",
+			"hc_black": "entity.other.attribute-name: #9CDCFE"
+		}
+	},
+	{
+		"c": "=",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.orientation.html punctuation.separator.key-value.html",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "\"",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.orientation.html string.quoted.double.html punctuation.definition.string.begin.html",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string.quoted.double.html: #0000FF",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string.quoted.double.html: #0000FF",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "vertical",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.orientation.html string.quoted.double.html",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string.quoted.double.html: #0000FF",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string.quoted.double.html: #0000FF",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "\"",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.orientation.html string.quoted.double.html punctuation.definition.string.end.html",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string.quoted.double.html: #0000FF",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string.quoted.double.html: #0000FF",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ">",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "PascalCase",
+		"t": "text.html.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "</",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "StackLayout",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "<",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "WelcomeMessage",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "greetingText",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.greetingText.html entity.other.attribute-name.html",
+		"r": {
+			"dark_plus": "entity.other.attribute-name: #9CDCFE",
+			"light_plus": "entity.other.attribute-name: #FF0000",
+			"dark_vs": "entity.other.attribute-name: #9CDCFE",
+			"light_vs": "entity.other.attribute-name: #FF0000",
+			"hc_black": "entity.other.attribute-name: #9CDCFE"
+		}
+	},
+	{
+		"c": "=",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.greetingText.html punctuation.separator.key-value.html",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "\"",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.greetingText.html string.quoted.double.html punctuation.definition.string.begin.html",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string.quoted.double.html: #0000FF",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string.quoted.double.html: #0000FF",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "hi",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.greetingText.html string.quoted.double.html",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string.quoted.double.html: #0000FF",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string.quoted.double.html: #0000FF",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "\"",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.greetingText.html string.quoted.double.html punctuation.definition.string.end.html",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string.quoted.double.html: #0000FF",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string.quoted.double.html: #0000FF",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": " />",
+		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "text ",
+		"t": "text.html.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "<",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "RainbowAnimate",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "PascalCase",
+		"t": "text.html.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "</",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "RainbowAnimate",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": ">",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": " text",
+		"t": "text.html.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	}
+]


### PR DESCRIPTION
Instead of requiring a name to match an existing HTML element, this relaxes the
restrictions to:

- starting with `[a-zA-Z]` (matching the HTML parser https://github.com/w3c/webcomponents/issues/239#issuecomment-190638288)
- then continuing with anything other than a space, forward slash or closing
  angle bracket
- using the `text.html.derivative` that is already used by VS Code (see https://github.com/textmate/html.tmbundle/issues/92 and https://github.com/microsoft/vscode/commit/cfc2a2212de9ea10943af58ebd1817a5ad196463)

This is similar to the fix to the following issue in the HTML syntax
highlighting repo (and actually depends on the "derivative" syntax that was
created for that issue):

https://github.com/textmate/html.tmbundle/issues/92

Closes #53