### PR TITLE
Make regexes compatible with latest oniguruma

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -212,7 +212,7 @@ repository:
   bold:
     begin: >
       (?x)
-      (\*\*(?=\w)|(?<!\w)\*\*|(?<!\w)\b__)(?=\S)
+      (?<open>(\*\*(?=\w)|(?<!\w)\*\*|(?<!\w)\b__))(?=\S)
       (?=
         (
           <[^>]*+>              # HTML tags
@@ -246,10 +246,10 @@ repository:
               )
             )
           )
-          | (?!(?<=\S)\1).            # Everything besides
+          | (?!(?<=\S)\k<open>).            # Everything besides
                             # style closer
         )++
-        (?<=\S)(?=__\b|\*\*)\1                # Close
+        (?<=\S)(?=__\b|\*\*)\k<open>                # Close
       )
     captures:
       '1': {name: punctuation.definition.bold.markdown}
@@ -323,7 +323,7 @@ repository:
   italic:
     begin: >
       (?x)
-      (\*(?=\w)|(?<!\w)\*|(?<!\w)\b_)(?=\S)                # Open
+      (?<open>(\*(?=\w)|(?<!\w)\*|(?<!\w)\b_))(?=\S)                # Open
         (?=
           (
             <[^>]*+>              # HTML tags
@@ -357,11 +357,11 @@ repository:
                 )
               )
             )
-            | \1\1                # Must be bold closer
-            | (?!(?<=\S)\1).            # Everything besides
+            | \k<open>\k<open>                # Must be bold closer
+            | (?!(?<=\S)\k<open>).            # Everything besides
                               # style closer
           )++
-          (?<=\S)(?=_\b|\*)\1                # Close
+          (?<=\S)(?=_\b|\*)\k<open>                # Close
         )
     captures:
       '1': {name: punctuation.definition.italic.markdown}

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3582,7 +3582,7 @@
       <key>bold</key>
       <dict>
         <key>begin</key>
-        <string>(?x) (\*\*(?=\w)|(?&lt;!\w)\*\*|(?&lt;!\w)\b__)(?=\S) (?=
+        <string>(?x) (?&lt;open&gt;(\*\*(?=\w)|(?&lt;!\w)\*\*|(?&lt;!\w)\b__))(?=\S) (?=
   (
     &lt;[^&gt;]*+&gt;              # HTML tags
     | (?&lt;raw&gt;`+)([^`]|(?!(?&lt;!`)\k&lt;raw&gt;(?!`))`)*+\k&lt;raw&gt;
@@ -3615,10 +3615,10 @@
         )
       )
     )
-    | (?!(?&lt;=\S)\1).            # Everything besides
+    | (?!(?&lt;=\S)\k&lt;open&gt;).            # Everything besides
                       # style closer
   )++
-  (?&lt;=\S)(?=__\b|\*\*)\1                # Close
+  (?&lt;=\S)(?=__\b|\*\*)\k&lt;open&gt;                # Close
 )
 </string>
         <key>captures</key>
@@ -3859,7 +3859,7 @@
       <key>italic</key>
       <dict>
         <key>begin</key>
-        <string>(?x) (\*(?=\w)|(?&lt;!\w)\*|(?&lt;!\w)\b_)(?=\S)                # Open
+        <string>(?x) (?&lt;open&gt;(\*(?=\w)|(?&lt;!\w)\*|(?&lt;!\w)\b_))(?=\S)                # Open
   (?=
     (
       &lt;[^&gt;]*+&gt;              # HTML tags
@@ -3893,11 +3893,11 @@
           )
         )
       )
-      | \1\1                # Must be bold closer
-      | (?!(?&lt;=\S)\1).            # Everything besides
+      | \k&lt;open&gt;\k&lt;open&gt;                # Must be bold closer
+      | (?!(?&lt;=\S)\k&lt;open&gt;).            # Everything besides
                         # style closer
     )++
-    (?&lt;=\S)(?=_\b|\*)\1                # Close
+    (?&lt;=\S)(?=_\b|\*)\k&lt;open&gt;                # Close
   )
 </string>
         <key>captures</key>


### PR DESCRIPTION

The latest [oniguruma](https://github.com/kkos/oniguruma) forbids mixing of numbered (`\1`) and named (`\k<name>`) backreferences.

I'm using `oniguruma` and the grammars from vscode to build a [terminal text editor](https://github.com/asottile/babi).

Without this patch, I get errors like:

```python
...
  File "/home/asottile/workspace/babi/venv/lib/python3.7/site-packages/onigurumacffi.py", line 143, in _compile_regex_t
    _check(ret, err_info)
  File "/home/asottile/workspace/babi/venv/lib/python3.7/site-packages/onigurumacffi.py", line 26, in _check
    raise OnigError(_err(code, *args))
onigurumacffi.OnigError: numbered backref/call is not allowed. (use name)
```

After fixing the two patterns I can successfully render the README of this project.


![Capture20](https://user-images.githubusercontent.com/1810591/75721174-c0ea9f80-5c8c-11ea-98c1-7f3d6c196be7.PNG)