### PR TITLE
Fix test

### DIFF
--- a/test/colorize-results/pr-57_md.json
+++ b/test/colorize-results/pr-57_md.json
@@ -256,8 +256,8 @@
 		"c": "var",
 		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.javascript meta.var.expr.js meta.var-single-variable.expr.js meta.definition.variable.js variable.other.constant.js",
 		"r": {
-			"dark_plus": "variable: #9CDCFE",
-			"light_plus": "variable: #001080",
+			"dark_plus": "variable.other.constant: #51B6C4",
+			"light_plus": "variable.other.constant: #328267",
 			"dark_vs": "meta.embedded: #D4D4D4",
 			"light_vs": "meta.embedded: #000000",
 			"hc_black": "variable: #9CDCFE"


### PR DESCRIPTION
Travis is failing because `var` in

```javascript
const var = 3;
```

is now scoped to `variable.other.constant` instead of just `variable`.
