### PR TITLE
Support Single Quotes for Link Titles

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -122,6 +122,9 @@ repository:
       '11': {name: string.other.link.description.title.markdown}
       '12': {name: punctuation.definition.string.begin.markdown}
       '13': {name: punctuation.definition.string.end.markdown}
+      '14': {name: string.other.link.description.title.markdown}
+      '15': {name: punctuation.definition.string.begin.markdown}
+      '16': {name: punctuation.definition.string.end.markdown}
       '2': {name: constant.other.reference.link.markdown}
       '3': {name: punctuation.definition.constant.markdown}
       '4': {name: punctuation.separator.key-value.markdown}
@@ -139,7 +142,8 @@ repository:
         [ \t]*          # Optional whitespace
         (?:
             ((\().+?(\)))    # Match title in parens…
-          | ((["']).+?(["']))    # or in quotes.
+          | ((").+?("))    # or in double quotes…
+          | ((').+?('))    # or in single quotes.
         )?            # Title is optional
         \s*            # Optional whitespace
         $
@@ -288,7 +292,10 @@ repository:
       '12': {name: string.other.link.description.title.markdown}
       '13': {name: punctuation.definition.string.markdown}
       '14': {name: punctuation.definition.string.markdown}
-      '15': {name: punctuation.definition.metadata.markdown}
+      '15': {name: string.other.link.description.title.markdown}
+      '16': {name: punctuation.definition.string.markdown}
+      '17': {name: punctuation.definition.string.markdown}
+      '18': {name: punctuation.definition.metadata.markdown}
       '2': {name: string.other.link.description.markdown}
       '4': {name: punctuation.definition.string.end.markdown}
       '5': {name: punctuation.definition.metadata.markdown}
@@ -305,7 +312,8 @@ repository:
           [ \t]*          # Optional whitespace
           (?:
               ((\().+?(\)))    # Match title in parens…
-            | ((["']).+?(["']))    # or in quotes.
+            | ((").+?("))    # or in double quotes…
+            | ((').+?('))    # or in single quotes.
           )?            # Title is optional
           \s*            # Optional whitespace
         (\))
@@ -415,7 +423,10 @@ repository:
       '13': {name: string.other.link.description.title.markdown}
       '14': {name: punctuation.definition.string.begin.markdown}
       '15': {name: punctuation.definition.string.end.markdown}
-      '16': {name: punctuation.definition.metadata.markdown}
+      '16': {name: string.other.link.description.title.markdown}
+      '17': {name: punctuation.definition.string.begin.markdown}
+      '18': {name: punctuation.definition.string.end.markdown}
+      '19': {name: punctuation.definition.metadata.markdown}
     match: >
       (?x)
         (\[)((?<square>[^\[\]\\]|\\.|\[\g<square>*+\])*+)(\])
@@ -425,7 +436,8 @@ repository:
           [ \t]*          # Optional whitespace
           (?:
               ((\().+?(\)))    # Match title in parens…
-            | ((["']).+?(["']))    # or in quotes.
+            | ((").+?("))    # or in double quotes…
+            | ((').+?('))    # or in single quotes.
           )?            # Title is optional
           \s*            # Optional whitespace
         (\))

--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -138,8 +138,8 @@ repository:
         (<?)(\S+?)(>?)      # The url
         [ \t]*          # Optional whitespace
         (?:
-            ((\().+?(\)))    # Match title in quotes…
-          | ((").+?("))    # or in parens.
+            ((\().+?(\)))    # Match title in parens…
+          | ((").+?("))    # or in quotes.
         )?            # Title is optional
         \s*            # Optional whitespace
         $

--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -139,7 +139,7 @@ repository:
         [ \t]*          # Optional whitespace
         (?:
             ((\().+?(\)))    # Match title in parens…
-          | ((").+?("))    # or in quotes.
+          | ((["']).+?(["']))    # or in quotes.
         )?            # Title is optional
         \s*            # Optional whitespace
         $

--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -305,7 +305,7 @@ repository:
           [ \t]*          # Optional whitespace
           (?:
               ((\().+?(\)))    # Match title in parens…
-            | ((").+?("))    # or in quotes.
+            | ((["']).+?(["']))    # or in quotes.
           )?            # Title is optional
           \s*            # Optional whitespace
         (\))
@@ -425,7 +425,7 @@ repository:
           [ \t]*          # Optional whitespace
           (?:
               ((\().+?(\)))    # Match title in parens…
-            | ((").+?("))    # or in quotes.
+            | ((["']).+?(["']))    # or in quotes.
           )?            # Title is optional
           \s*            # Optional whitespace
         (\))

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3472,7 +3472,7 @@
   [ \t]*          # Optional whitespace
   (?:
       ((\().+?(\)))    # Match title in parens…
-    | ((").+?("))    # or in quotes.
+    | ((["']).+?(["']))    # or in quotes.
   )?            # Title is optional
   \s*            # Optional whitespace
   $

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3471,8 +3471,8 @@
   (&lt;?)(\S+?)(&gt;?)      # The url
   [ \t]*          # Optional whitespace
   (?:
-      ((\().+?(\)))    # Match title in quotes…
-    | ((").+?("))    # or in parens.
+      ((\().+?(\)))    # Match title in parens…
+    | ((").+?("))    # or in quotes.
   )?            # Title is optional
   \s*            # Optional whitespace
   $

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3462,6 +3462,21 @@
             <key>name</key>
             <string>punctuation.definition.string.end.markdown</string>
           </dict>
+          <key>14</key>
+          <dict>
+            <key>name</key>
+            <string>string.other.link.description.title.markdown</string>
+          </dict>
+          <key>15</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.begin.markdown</string>
+          </dict>
+          <key>16</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.end.markdown</string>
+          </dict>
         </dict>
         <key>match</key>
         <string>(?x)
@@ -3472,7 +3487,8 @@
   [ \t]*          # Optional whitespace
   (?:
       ((\().+?(\)))    # Match title in parens…
-    | ((["']).+?(["']))    # or in quotes.
+    | ((").+?("))    # or in double quotes…
+    | ((').+?('))    # or in single quotes.
   )?            # Title is optional
   \s*            # Optional whitespace
   $
@@ -3910,6 +3926,21 @@
           <key>15</key>
           <dict>
             <key>name</key>
+            <string>string.other.link.description.title.markdown</string>
+          </dict>
+          <key>16</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.markdown</string>
+          </dict>
+          <key>17</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.markdown</string>
+          </dict>
+          <key>18</key>
+          <dict>
+            <key>name</key>
             <string>punctuation.definition.metadata.markdown</string>
           </dict>
         </dict>
@@ -3922,7 +3953,8 @@
     [ \t]*          # Optional whitespace
     (?:
         ((\().+?(\)))    # Match title in parens…
-      | ((["']).+?(["']))    # or in quotes.
+      | ((").+?("))    # or in double quotes…
+      | ((').+?('))    # or in single quotes.
     )?            # Title is optional
     \s*            # Optional whitespace
   (\))
@@ -4219,6 +4251,21 @@
           <key>16</key>
           <dict>
             <key>name</key>
+            <string>string.other.link.description.title.markdown</string>
+          </dict>
+          <key>17</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.begin.markdown</string>
+          </dict>
+          <key>18</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.end.markdown</string>
+          </dict>
+          <key>19</key>
+          <dict>
+            <key>name</key>
             <string>punctuation.definition.metadata.markdown</string>
           </dict>
         </dict>
@@ -4231,7 +4278,8 @@
     [ \t]*          # Optional whitespace
     (?:
         ((\().+?(\)))    # Match title in parens…
-      | ((["']).+?(["']))    # or in quotes.
+      | ((").+?("))    # or in double quotes…
+      | ((').+?('))    # or in single quotes.
     )?            # Title is optional
     \s*            # Optional whitespace
   (\))

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3922,7 +3922,7 @@
     [ \t]*          # Optional whitespace
     (?:
         ((\().+?(\)))    # Match title in parens…
-      | ((").+?("))    # or in quotes.
+      | ((["']).+?(["']))    # or in quotes.
     )?            # Title is optional
     \s*            # Optional whitespace
   (\))
@@ -4231,7 +4231,7 @@
     [ \t]*          # Optional whitespace
     (?:
         ((\().+?(\)))    # Match title in parens…
-      | ((").+?("))    # or in quotes.
+      | ((["']).+?(["']))    # or in quotes.
     )?            # Title is optional
     \s*            # Optional whitespace
   (\))

--- a/test/colorize-fixtures/issue-67-81.md
+++ b/test/colorize-fixtures/issue-67-81.md
@@ -1,0 +1,3 @@
+[a link](http://example.com "title")
+[a link](http://example.com (title))
+[a link](http://example.com 'title')

--- a/test/colorize-results/issue-67-81_md.json
+++ b/test/colorize-results/issue-67-81_md.json
@@ -1,0 +1,332 @@
+[
+	{
+		"c": "[",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "a link",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "]",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "http://example.com",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown markup.underline.link.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "\"",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "title",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "\"",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ")",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "[",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "a link",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "]",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "http://example.com",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown markup.underline.link.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "title",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ")",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ")",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "[",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "a link",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "]",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "http://example.com",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown markup.underline.link.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "title",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ")",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	}
+]


### PR DESCRIPTION
Description
This commit fixes syntax highlighting for inline link titles that use single quotes. For more information, please take a look at issue #67 and #81. If I should change anything in this PR, then please just comment below.