### PR TITLE
Add rule for paths with spaces.

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -221,6 +221,7 @@ repository:
     - {include: '#link-ref'}
     - {include: '#link-ref-literal'}
     - {include: '#link-ref-shortcut'}
+    - {include: '#link-html'}
   ampersand:
     comment: "Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid."
     match: '&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)'
@@ -291,6 +292,7 @@ repository:
     - {include: '#link-ref-literal'}
     - {include: '#link-ref'}
     - {include: '#link-ref-shortcut'}
+    - {include: '#link-html'}
   bracket:
     comment: "Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid."
     match: '<(?![a-zA-Z/?\$!])'
@@ -406,6 +408,7 @@ repository:
     - {include: '#link-ref-literal'}
     - {include: '#link-ref'}
     - {include: '#link-ref-shortcut'}
+    - {include: '#link-html'}
   link-email:
     captures:
       '1': {name: punctuation.definition.link.markdown}
@@ -480,6 +483,13 @@ repository:
       '3': {name: punctuation.definition.string.end.markdown}
     match: (\[)(\S+?)(\])
     name: meta.link.reference.markdown
+  link-html:
+    captures:
+      '1': {name: punctuation.definition.link.markdown}
+      '2': {name: markup.underline.link.markdown}
+      '3': {name: punctuation.definition.link.markdown}
+    match: (?<=\[.*\]\()(\<)(.*?)(\>)
+    name: meta.link.inline.markdown
   raw:
     captures:
       '1': {name: punctuation.definition.raw.markdown}

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3764,6 +3764,10 @@
             <key>include</key>
             <string>#link-ref-shortcut</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#link-html</string>
+          </dict>
         </array>
       </dict>
       <key>ampersand</key>
@@ -3901,6 +3905,10 @@
           <dict>
             <key>include</key>
             <string>#link-ref-shortcut</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#link-html</string>
           </dict>
         </array>
       </dict>
@@ -4193,6 +4201,10 @@
             <key>include</key>
             <string>#link-ref-shortcut</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#link-html</string>
+          </dict>
         </array>
       </dict>
       <key>link-email</key>
@@ -4452,6 +4464,31 @@
         <string>(\[)(\S+?)(\])</string>
         <key>name</key>
         <string>meta.link.reference.markdown</string>
+      </dict>
+      <key>link-html</key>
+      <dict>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.link.markdown</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>markup.underline.link.markdown</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.link.markdown</string>
+          </dict>
+        </dict>
+        <key>match</key>
+        <string>(?&lt;=\[.*\]\()(\&lt;)(.*?)(\&gt;)</string>
+        <key>name</key>
+        <string>meta.link.inline.markdown</string>
       </dict>
       <key>raw</key>
       <dict>

--- a/test/colorize-fixtures/issue-80.md
+++ b/test/colorize-fixtures/issue-80.md
@@ -1,0 +1,1 @@
+[title]<path with spaces>

--- a/test/colorize-results/issue-80_md.json
+++ b/test/colorize-results/issue-80_md.json
@@ -1,0 +1,112 @@
+[
+	{
+		"c": "[",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "title",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "]",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "<",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.begin.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	},
+	{
+		"c": "path",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
+		"r": {
+			"dark_plus": "entity.name.tag: #569CD6",
+			"light_plus": "entity.name.tag: #800000",
+			"dark_vs": "entity.name.tag: #569CD6",
+			"light_vs": "entity.name.tag: #800000",
+			"hc_black": "entity.name.tag: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "with",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.with.html entity.other.attribute-name.html",
+		"r": {
+			"dark_plus": "entity.other.attribute-name: #9CDCFE",
+			"light_plus": "entity.other.attribute-name: #FF0000",
+			"dark_vs": "entity.other.attribute-name: #9CDCFE",
+			"light_vs": "entity.other.attribute-name: #FF0000",
+			"hc_black": "entity.other.attribute-name: #9CDCFE"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "spaces",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.spaces.html entity.other.attribute-name.html",
+		"r": {
+			"dark_plus": "entity.other.attribute-name: #9CDCFE",
+			"light_plus": "entity.other.attribute-name: #FF0000",
+			"dark_vs": "entity.other.attribute-name: #9CDCFE",
+			"light_vs": "entity.other.attribute-name: #FF0000",
+			"hc_black": "entity.other.attribute-name: #9CDCFE"
+		}
+	},
+	{
+		"c": ">",
+		"t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative punctuation.definition.tag.end.html",
+		"r": {
+			"dark_plus": "punctuation.definition.tag: #808080",
+			"light_plus": "punctuation.definition.tag: #800000",
+			"dark_vs": "punctuation.definition.tag: #808080",
+			"light_vs": "punctuation.definition.tag: #800000",
+			"hc_black": "punctuation.definition.tag: #808080"
+		}
+	}
+]


### PR DESCRIPTION
Weird case where the `Inspect Tokens` command shows the correct tokens: (See how the first is correct but the second is not)

<img width="737" alt="Screen Shot 2021-10-08 at 4 58 17 PM" src="https://user-images.githubusercontent.com/12758612/136636223-245fc3da-1144-42a0-b51a-4dfde9445b7f.png">

<img width="763" alt="Screen Shot 2021-10-08 at 4 58 12 PM" src="https://user-images.githubusercontent.com/12758612/136636224-c51b6974-33b8-46b0-9ce2-4d07513eae94.png">

However on run of testcase for `[title]<path with spaces>` it shows the incorrect tokens for the text:
```json
{
    "c": "path",
    "t": "text.html.markdown meta.paragraph.markdown meta.tag.other.unrecognized.html.derivative entity.name.tag.html",
    "r": {
	"dark_plus": "entity.name.tag: #569CD6",
	"light_plus": "entity.name.tag: #800000",
	"dark_vs": "entity.name.tag: #569CD6",
	"light_vs": "entity.name.tag: #800000",
	"hc_black": "entity.name.tag: #569CD6"
    }
}

```

Not sure if it's a bug with VS Code or how I added the rule.

Related to #80

