### PR TITLE
Support latex fenced code blocks

### DIFF
--- a/build.js
+++ b/build.js
@@ -62,7 +62,9 @@ const languages = [
 	{ name: 'markdown', language: 'markdown', identifiers: ['markdown', 'md'], source: 'text.html.markdown' },
 	{ name: 'log', language: 'log', identifiers: ['log'], source: 'text.log' },
 	{ name: 'erlang', language: 'erlang', identifiers: ['erlang'], source: 'source.erlang' },
-	{ name: 'elixir', language: 'elixir', identifiers: ['elixir'], source: 'source.elixir' }
+	{ name: 'elixir', language: 'elixir', identifiers: ['elixir'], source: 'source.elixir' },
+	{ name: 'latex', language: 'latex', identifiers: ['latex', 'tex'], source: 'text.tex.latex' },
+	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' }
 ];
 
 const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, additionalContentName) => {

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -2852,6 +2852,112 @@
           </dict>
         </array>
       </dict>
+      <key>fenced_code_block_latex</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <key>name</key>
+        <string>markup.fenced_code.block.markdown</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.markdown</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.attributes.markdown</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.latex</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>text.tex.latex</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>fenced_code_block_bibtex</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <key>name</key>
+        <string>markup.fenced_code.block.markdown</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.markdown</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.attributes.markdown</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.bibtex</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>text.bibtex</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
       <key>fenced_code_block</key>
       <dict>
         <key>patterns</key>
@@ -3063,6 +3169,14 @@
           <dict>
             <key>include</key>
             <string>#fenced_code_block_elixir</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#fenced_code_block_latex</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#fenced_code_block_bibtex</string>
           </dict>
           <dict>
             <key>include</key>


### PR DESCRIPTION
I am a PM at https://github.com/James-Yu/LaTeX-Workshop. We are extracting the latex grammars to make a basic language extension for latex, which will be a a built-in extension in VS Code, see https://github.com/James-Yu/LaTeX-Workshop/issues/2983. The new extension is developed at https://github.com/jlelong/vscode-latex-basics.

Latex fenced code blocks in markdown are currently supported through a grammar injection carried by the LaTeX-Workshop extension. We believe that once the latex grammars are provided as a built-in extension in VS Code, latex fenced code blocks should be directly handle by the markdown grammars, see jlelong/vscode-latex-basics#1. Hence this PR. What do you think?
