### PR TITLE
🐛 Fix single tilde (`~`) strikethrough parsing

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -515,7 +515,7 @@ repository:
         - {include: '#link-ref'}
         - {include: '#link-ref-shortcut'}
       '3': {name: punctuation.definition.strikethrough.markdown}
-    match: (~+)((?:[^~]|(?!(?<!~)\1(?!~))~)*+)(\1)
+    match: (~{2,})((?:[^~]|(?!(?<!~)\1(?!~))~)*+)(\1)
     name: markup.strikethrough.markdown
 scopeName: text.html.markdown
 uuid: 0A1D9874-B448-11D9-BD50-000D93B6E43C

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -4697,7 +4697,7 @@
           </dict>
         </dict>
         <key>match</key>
-        <string>(~+)((?:[^~]|(?!(?&lt;!~)\1(?!~))~)*+)(\1)</string>
+        <string>(~{2,})((?:[^~]|(?!(?&lt;!~)\1(?!~))~)*+)(\1)</string>
         <key>name</key>
         <string>markup.strikethrough.markdown</string>
       </dict>

--- a/test/colorization.test.js
+++ b/test/colorization.test.js
@@ -34,7 +34,7 @@ function assertUnchangedTokens(testFixurePath, done) {
                                 throw e;
                             }
                         }
-                        // different but no tokenization ot color change: no failure
+                        // different but no tokenization or color change: no failure
                     } else {
                         throw e;
                     }

--- a/test/colorize-fixtures/issue-100.md
+++ b/test/colorize-fixtures/issue-100.md
@@ -1,5 +1,3 @@
-~test~
-
 ~~test~~
 
 ~~*test*~~

--- a/test/colorize-fixtures/issues-vs-146610.md
+++ b/test/colorize-fixtures/issues-vs-146610.md
@@ -1,0 +1,3 @@
+~text-without-strikethrough~
+
+~~text-with-strikethrough~~

--- a/test/colorize-results/issue-100_md.json
+++ b/test/colorize-results/issue-100_md.json
@@ -1,38 +1,5 @@
 [
 	{
-		"c": "~",
-		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown punctuation.definition.strikethrough.markdown",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
-		"c": "test",
-		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
-		"c": "~",
-		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown punctuation.definition.strikethrough.markdown",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
 		"c": "~~",
 		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown punctuation.definition.strikethrough.markdown",
 		"r": {

--- a/test/colorize-results/issues-vs-146610_md.json
+++ b/test/colorize-results/issues-vs-146610_md.json
@@ -1,0 +1,50 @@
+[
+	{
+		"c": "~text-without-strikethrough~",
+		"t": "text.html.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "~~",
+		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown punctuation.definition.strikethrough.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "text-with-strikethrough",
+		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "~~",
+		"t": "text.html.markdown meta.paragraph.markdown markup.strikethrough.markdown punctuation.definition.strikethrough.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	}
+]

--- a/test/colorize-results/issues-vs-146610_md.json
+++ b/test/colorize-results/issues-vs-146610_md.json
@@ -7,8 +7,7 @@
 			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF",
-			"hc_light": "default: #292929"
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
@@ -19,8 +18,7 @@
 			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF",
-			"hc_light": "default: #292929"
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
@@ -31,8 +29,7 @@
 			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF",
-			"hc_light": "default: #292929"
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
@@ -43,8 +40,7 @@
 			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF",
-			"hc_light": "default: #292929"
+			"hc_black": "default: #FFFFFF"
 		}
 	}
 ]


### PR DESCRIPTION
This PR fixes microsoft/vscode#146610