### PR TITLE
Add support for juila

### DIFF
--- a/build.js
+++ b/build.js
@@ -49,6 +49,7 @@ const languages = [
 	{ name: 'perl6', language: 'perl6', identifiers: ['perl6', 'p6', 'pl6', 'pm6', 'nqp'], source: 'source.perl.6' },
 	{ name: 'powershell', language: 'powershell', identifiers: ['powershell', 'ps1', 'psm1', 'psd1'], source: 'source.powershell' },
 	{ name: 'python', language: 'python', identifiers: ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi', '\\{\\.python.+?\\}'], source: 'source.python' },
+	{ name: 'julia', language: 'julia', identifiers: ['julia', '\\{\\.julia.+?\\}'], source: 'source.julia' },
 	{ name: 'regexp_python', identifiers: ['re'], source: 'source.regexp.python' },
 	{ name: 'rust', language: 'rust', identifiers: ['rust', 'rs', '\\{\\.rust.+?\\}'], source: 'source.rust' },
 	{ name: 'scala', language: 'scala', identifiers: ['scala', 'sbt'], source: 'source.scala' },


### PR DESCRIPTION
This adds support for the Julia language. Though this already exists in the julia extension, this supports a more general syntax when using pandoc style markdown (useful for, e.g. https://github.com/gpoore/vscode-codebraid-preview/pull/4)