### PR TITLE
Lint README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 [![Build Status](https://dev.azure.com/monacotools/Monaco/_apis/build/status/Extensions/microsoft.vscode-markdown-tm-grammar?branchName=main)](https://dev.azure.com/monacotools/Monaco/_build/latest?definitionId=203&branchName=main)
 
-VS Code markdown extension's Textmate grammar.
+VS Code markdown extension's TextMate grammar.
 
-# Contributing
+## Contributing
+
 The main grammar is stored in `syntaxes/markdown.tmLanguage`. This file is generated from `markdown.tmLanguage.base.yaml`:
 
-## Building
+### Building
+
 To generate the main grammar:
 
-```bash
-$ npm install
-$ npm run build 
+```console
+npm install
+npm run build
 ```
 
-## Testing
+### Testing
+
 To run the grammar tests:
 
-```bash
-$ npm run test
+```console
+npm run test
 ```
 
 The test cases are stored as markdown files under `test/colorize-fixtures`. Grammar test results are stored under `test/colorize-results`, which are automatically generated from the fixtures.
 
 To test the grammar in VS Code, select the `Launch Extension` configuration in the VS Code debugger and run.
-


### PR DESCRIPTION
Noticed the `README.md` does not follow markdown lint rules.
This should fix that.

Technically the `CODE_OF_CONDUCT.md` also does not follow markdown lint rules as the first line in a markdown file must start with a top level heading. If you'd like I can add a commit to this PR to add that?