### PR TITLE
Add support for tildes in attributes of fenced code block

### DIFF
--- a/build.js
+++ b/build.js
@@ -85,7 +85,7 @@ const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, add
 
 	return `fenced_code_block_${name}:
   begin:
-    (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?i:(${identifiers.join('|')})((\\s+|:|,|\\{|\\?)[^\`~]*)?$)
+    (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?i:(${identifiers.join('|')})((\\s+|:|,|\\{|\\?).*)?$)
   name:
     markup.fenced_code.block.markdown
   end:

--- a/build.js
+++ b/build.js
@@ -85,7 +85,7 @@ const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, add
 
 	return `fenced_code_block_${name}:
   begin:
-    (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?i:(${identifiers.join('|')})((\\s+|:|,|\\{|\\?).*)?$)
+    (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?i:(${identifiers.join('|')})((\\s+|:|,|\\{|\\?)(?:(?!\`{3}|~{3}).)*)?$)
   name:
     markup.fenced_code.block.markdown
   end:

--- a/build.js
+++ b/build.js
@@ -85,7 +85,7 @@ const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, add
 
 	return `fenced_code_block_${name}:
   begin:
-    (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?i:(${identifiers.join('|')})((\\s+|:|,|\\{|\\?)(?:(?!\`{3}|~{3}).)*)?$)
+    (^|\\G)(\\s*)(\`{3,}|~{3,})\\s*(?i:(${identifiers.join('|')})((\\s+|:|,|\\{|\\?)[^\`]*)?$)
   name:
     markup.fenced_code.block.markdown
   end:

--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -30,7 +30,7 @@ repository:
     {{languageIncludes}}
     - {include: '#fenced_code_block_unknown'}
   fenced_code_block_unknown:
-    begin: (^|\G)(\s*)(`{3,}|~{3,})\s*(?=([^`~]*)?$)
+    begin: (^|\G)(\s*)(`{3,}|~{3,})\s*(?=([^`]*)?$)
     beginCaptures:
       '3': {name: punctuation.definition.markdown}
       '4': {name: fenced_code.block.language}

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -95,7 +95,7 @@
       <key>fenced_code_block_css</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(css|css.erb)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(css|css.erb)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -148,7 +148,7 @@
       <key>fenced_code_block_basic</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(html|htm|shtml|xhtml|inc|tmpl|tpl)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(html|htm|shtml|xhtml|inc|tmpl|tpl)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -201,7 +201,7 @@
       <key>fenced_code_block_ini</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ini|conf)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ini|conf)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -254,7 +254,7 @@
       <key>fenced_code_block_java</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(java|bsh)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(java|bsh)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -307,7 +307,7 @@
       <key>fenced_code_block_lua</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(lua)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(lua)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -360,7 +360,7 @@
       <key>fenced_code_block_makefile</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(Makefile|makefile|GNUmakefile|OCamlMakefile)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(Makefile|makefile|GNUmakefile|OCamlMakefile)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -413,7 +413,7 @@
       <key>fenced_code_block_perl</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl|pl|pm|pod|t|PL|psgi|vcl)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl|pl|pm|pod|t|PL|psgi|vcl)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -466,7 +466,7 @@
       <key>fenced_code_block_r</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(R|r|s|S|Rprofile|\{\.r.+?\})((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(R|r|s|S|Rprofile|\{\.r.+?\})((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -519,7 +519,7 @@
       <key>fenced_code_block_ruby</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -572,7 +572,7 @@
       <key>fenced_code_block_php</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(php|php3|php4|php5|phpt|phtml|aw|ctp)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(php|php3|php4|php5|phpt|phtml|aw|ctp)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -629,7 +629,7 @@
       <key>fenced_code_block_sql</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(sql|ddl|dml)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(sql|ddl|dml)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -682,7 +682,7 @@
       <key>fenced_code_block_vs_net</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(vb)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(vb)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -735,7 +735,7 @@
       <key>fenced_code_block_xml</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -788,7 +788,7 @@
       <key>fenced_code_block_xsl</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xsl|xslt)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xsl|xslt)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -841,7 +841,7 @@
       <key>fenced_code_block_yaml</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(yaml|yml)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(yaml|yml)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -894,7 +894,7 @@
       <key>fenced_code_block_dosbatch</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bat|batch)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bat|batch)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -947,7 +947,7 @@
       <key>fenced_code_block_clojure</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(clj|cljs|clojure)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(clj|cljs|clojure)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1000,7 +1000,7 @@
       <key>fenced_code_block_coffee</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(coffee|Cakefile|coffee.erb)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(coffee|Cakefile|coffee.erb)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1053,7 +1053,7 @@
       <key>fenced_code_block_c</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(c|h)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(c|h)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1106,7 +1106,7 @@
       <key>fenced_code_block_cpp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cpp|c\+\+|cxx)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cpp|c\+\+|cxx)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1159,7 +1159,7 @@
       <key>fenced_code_block_diff</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(patch|diff|rej)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(patch|diff|rej)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1212,7 +1212,7 @@
       <key>fenced_code_block_dockerfile</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dockerfile|Dockerfile)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dockerfile|Dockerfile)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1265,7 +1265,7 @@
       <key>fenced_code_block_git_commit</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(COMMIT_EDITMSG|MERGE_MSG)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(COMMIT_EDITMSG|MERGE_MSG)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1318,7 +1318,7 @@
       <key>fenced_code_block_git_rebase</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(git-rebase-todo)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(git-rebase-todo)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1371,7 +1371,7 @@
       <key>fenced_code_block_go</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(go|golang)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(go|golang)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1424,7 +1424,7 @@
       <key>fenced_code_block_groovy</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(groovy|gvy)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(groovy|gvy)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1477,7 +1477,7 @@
       <key>fenced_code_block_pug</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1530,7 +1530,7 @@
       <key>fenced_code_block_js</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(js|jsx|javascript|es6|mjs|cjs|dataviewjs|\{\.js.+?\})((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(js|jsx|javascript|es6|mjs|cjs|dataviewjs|\{\.js.+?\})((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1583,7 +1583,7 @@
       <key>fenced_code_block_js_regexp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(regexp)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(regexp)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1636,7 +1636,7 @@
       <key>fenced_code_block_json</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(json|json5|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(json|json5|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1689,7 +1689,7 @@
       <key>fenced_code_block_jsonc</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1742,7 +1742,7 @@
       <key>fenced_code_block_less</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(less)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(less)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1795,7 +1795,7 @@
       <key>fenced_code_block_objc</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(objectivec|objective-c|mm|objc|obj-c|m|h)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(objectivec|objective-c|mm|objc|obj-c|m|h)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1848,7 +1848,7 @@
       <key>fenced_code_block_swift</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(swift)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(swift)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1901,7 +1901,7 @@
       <key>fenced_code_block_scss</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scss)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scss)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1954,7 +1954,7 @@
       <key>fenced_code_block_perl6</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl6|p6|pl6|pm6|nqp)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl6|p6|pl6|pm6|nqp)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2007,7 +2007,7 @@
       <key>fenced_code_block_powershell</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(powershell|ps1|psm1|psd1)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(powershell|ps1|psm1|psd1)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2060,7 +2060,7 @@
       <key>fenced_code_block_python</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|\{\.python.+?\})((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|\{\.python.+?\})((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2113,7 +2113,7 @@
       <key>fenced_code_block_julia</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(julia|\{\.julia.+?\})((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(julia|\{\.julia.+?\})((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2166,7 +2166,7 @@
       <key>fenced_code_block_regexp_python</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(re)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(re)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2219,7 +2219,7 @@
       <key>fenced_code_block_rust</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(rust|rs|\{\.rust.+?\})((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(rust|rs|\{\.rust.+?\})((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2272,7 +2272,7 @@
       <key>fenced_code_block_scala</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scala|sbt)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scala|sbt)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2325,7 +2325,7 @@
       <key>fenced_code_block_shell</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init|\{\.bash.+?\})((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init|\{\.bash.+?\})((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2378,7 +2378,7 @@
       <key>fenced_code_block_ts</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(typescript|ts)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(typescript|ts)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2431,7 +2431,7 @@
       <key>fenced_code_block_tsx</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(tsx)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(tsx)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2484,7 +2484,7 @@
       <key>fenced_code_block_csharp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cs|csharp|c#)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cs|csharp|c#)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2537,7 +2537,7 @@
       <key>fenced_code_block_fsharp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(fs|fsharp|f#)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(fs|fsharp|f#)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2590,7 +2590,7 @@
       <key>fenced_code_block_dart</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dart)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dart)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2643,7 +2643,7 @@
       <key>fenced_code_block_handlebars</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(handlebars|hbs)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(handlebars|hbs)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2696,7 +2696,7 @@
       <key>fenced_code_block_markdown</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(markdown|md)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(markdown|md)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2749,7 +2749,7 @@
       <key>fenced_code_block_log</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(log)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(log)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2802,7 +2802,7 @@
       <key>fenced_code_block_erlang</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(erlang)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(erlang)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2855,7 +2855,7 @@
       <key>fenced_code_block_elixir</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(elixir)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(elixir)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2908,7 +2908,7 @@
       <key>fenced_code_block_latex</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2961,7 +2961,7 @@
       <key>fenced_code_block_bibtex</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?)[^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?).*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -95,7 +95,7 @@
       <key>fenced_code_block_css</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(css|css.erb)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(css|css.erb)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -148,7 +148,7 @@
       <key>fenced_code_block_basic</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(html|htm|shtml|xhtml|inc|tmpl|tpl)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(html|htm|shtml|xhtml|inc|tmpl|tpl)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -201,7 +201,7 @@
       <key>fenced_code_block_ini</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ini|conf)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ini|conf)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -254,7 +254,7 @@
       <key>fenced_code_block_java</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(java|bsh)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(java|bsh)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -307,7 +307,7 @@
       <key>fenced_code_block_lua</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(lua)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(lua)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -360,7 +360,7 @@
       <key>fenced_code_block_makefile</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(Makefile|makefile|GNUmakefile|OCamlMakefile)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(Makefile|makefile|GNUmakefile|OCamlMakefile)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -413,7 +413,7 @@
       <key>fenced_code_block_perl</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl|pl|pm|pod|t|PL|psgi|vcl)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl|pl|pm|pod|t|PL|psgi|vcl)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -466,7 +466,7 @@
       <key>fenced_code_block_r</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(R|r|s|S|Rprofile|\{\.r.+?\})((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(R|r|s|S|Rprofile|\{\.r.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -519,7 +519,7 @@
       <key>fenced_code_block_ruby</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -572,7 +572,7 @@
       <key>fenced_code_block_php</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(php|php3|php4|php5|phpt|phtml|aw|ctp)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(php|php3|php4|php5|phpt|phtml|aw|ctp)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -629,7 +629,7 @@
       <key>fenced_code_block_sql</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(sql|ddl|dml)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(sql|ddl|dml)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -682,7 +682,7 @@
       <key>fenced_code_block_vs_net</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(vb)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(vb)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -735,7 +735,7 @@
       <key>fenced_code_block_xml</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -788,7 +788,7 @@
       <key>fenced_code_block_xsl</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xsl|xslt)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xsl|xslt)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -841,7 +841,7 @@
       <key>fenced_code_block_yaml</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(yaml|yml)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(yaml|yml)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -894,7 +894,7 @@
       <key>fenced_code_block_dosbatch</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bat|batch)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bat|batch)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -947,7 +947,7 @@
       <key>fenced_code_block_clojure</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(clj|cljs|clojure)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(clj|cljs|clojure)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1000,7 +1000,7 @@
       <key>fenced_code_block_coffee</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(coffee|Cakefile|coffee.erb)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(coffee|Cakefile|coffee.erb)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1053,7 +1053,7 @@
       <key>fenced_code_block_c</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(c|h)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(c|h)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1106,7 +1106,7 @@
       <key>fenced_code_block_cpp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cpp|c\+\+|cxx)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cpp|c\+\+|cxx)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1159,7 +1159,7 @@
       <key>fenced_code_block_diff</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(patch|diff|rej)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(patch|diff|rej)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1212,7 +1212,7 @@
       <key>fenced_code_block_dockerfile</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dockerfile|Dockerfile)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dockerfile|Dockerfile)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1265,7 +1265,7 @@
       <key>fenced_code_block_git_commit</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(COMMIT_EDITMSG|MERGE_MSG)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(COMMIT_EDITMSG|MERGE_MSG)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1318,7 +1318,7 @@
       <key>fenced_code_block_git_rebase</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(git-rebase-todo)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(git-rebase-todo)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1371,7 +1371,7 @@
       <key>fenced_code_block_go</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(go|golang)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(go|golang)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1424,7 +1424,7 @@
       <key>fenced_code_block_groovy</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(groovy|gvy)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(groovy|gvy)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1477,7 +1477,7 @@
       <key>fenced_code_block_pug</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1530,7 +1530,7 @@
       <key>fenced_code_block_js</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(js|jsx|javascript|es6|mjs|cjs|dataviewjs|\{\.js.+?\})((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(js|jsx|javascript|es6|mjs|cjs|dataviewjs|\{\.js.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1583,7 +1583,7 @@
       <key>fenced_code_block_js_regexp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(regexp)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(regexp)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1636,7 +1636,7 @@
       <key>fenced_code_block_json</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(json|json5|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(json|json5|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1689,7 +1689,7 @@
       <key>fenced_code_block_jsonc</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1742,7 +1742,7 @@
       <key>fenced_code_block_less</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(less)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(less)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1795,7 +1795,7 @@
       <key>fenced_code_block_objc</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(objectivec|objective-c|mm|objc|obj-c|m|h)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(objectivec|objective-c|mm|objc|obj-c|m|h)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1848,7 +1848,7 @@
       <key>fenced_code_block_swift</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(swift)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(swift)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1901,7 +1901,7 @@
       <key>fenced_code_block_scss</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scss)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scss)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1954,7 +1954,7 @@
       <key>fenced_code_block_perl6</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl6|p6|pl6|pm6|nqp)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl6|p6|pl6|pm6|nqp)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2007,7 +2007,7 @@
       <key>fenced_code_block_powershell</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(powershell|ps1|psm1|psd1)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(powershell|ps1|psm1|psd1)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2060,7 +2060,7 @@
       <key>fenced_code_block_python</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|\{\.python.+?\})((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|\{\.python.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2113,7 +2113,7 @@
       <key>fenced_code_block_julia</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(julia|\{\.julia.+?\})((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(julia|\{\.julia.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2166,7 +2166,7 @@
       <key>fenced_code_block_regexp_python</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(re)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(re)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2219,7 +2219,7 @@
       <key>fenced_code_block_rust</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(rust|rs|\{\.rust.+?\})((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(rust|rs|\{\.rust.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2272,7 +2272,7 @@
       <key>fenced_code_block_scala</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scala|sbt)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scala|sbt)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2325,7 +2325,7 @@
       <key>fenced_code_block_shell</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init|\{\.bash.+?\})((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init|\{\.bash.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2378,7 +2378,7 @@
       <key>fenced_code_block_ts</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(typescript|ts)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(typescript|ts)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2431,7 +2431,7 @@
       <key>fenced_code_block_tsx</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(tsx)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(tsx)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2484,7 +2484,7 @@
       <key>fenced_code_block_csharp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cs|csharp|c#)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cs|csharp|c#)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2537,7 +2537,7 @@
       <key>fenced_code_block_fsharp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(fs|fsharp|f#)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(fs|fsharp|f#)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2590,7 +2590,7 @@
       <key>fenced_code_block_dart</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dart)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dart)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2643,7 +2643,7 @@
       <key>fenced_code_block_handlebars</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(handlebars|hbs)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(handlebars|hbs)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2696,7 +2696,7 @@
       <key>fenced_code_block_markdown</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(markdown|md)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(markdown|md)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2749,7 +2749,7 @@
       <key>fenced_code_block_log</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(log)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(log)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2802,7 +2802,7 @@
       <key>fenced_code_block_erlang</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(erlang)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(erlang)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2855,7 +2855,7 @@
       <key>fenced_code_block_elixir</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(elixir)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(elixir)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2908,7 +2908,7 @@
       <key>fenced_code_block_latex</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2961,7 +2961,7 @@
       <key>fenced_code_block_bibtex</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?).*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -95,7 +95,7 @@
       <key>fenced_code_block_css</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(css|css.erb)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(css|css.erb)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -148,7 +148,7 @@
       <key>fenced_code_block_basic</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(html|htm|shtml|xhtml|inc|tmpl|tpl)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(html|htm|shtml|xhtml|inc|tmpl|tpl)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -201,7 +201,7 @@
       <key>fenced_code_block_ini</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ini|conf)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ini|conf)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -254,7 +254,7 @@
       <key>fenced_code_block_java</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(java|bsh)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(java|bsh)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -307,7 +307,7 @@
       <key>fenced_code_block_lua</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(lua)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(lua)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -360,7 +360,7 @@
       <key>fenced_code_block_makefile</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(Makefile|makefile|GNUmakefile|OCamlMakefile)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(Makefile|makefile|GNUmakefile|OCamlMakefile)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -413,7 +413,7 @@
       <key>fenced_code_block_perl</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl|pl|pm|pod|t|PL|psgi|vcl)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl|pl|pm|pod|t|PL|psgi|vcl)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -466,7 +466,7 @@
       <key>fenced_code_block_r</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(R|r|s|S|Rprofile|\{\.r.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(R|r|s|S|Rprofile|\{\.r.+?\})((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -519,7 +519,7 @@
       <key>fenced_code_block_ruby</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -572,7 +572,7 @@
       <key>fenced_code_block_php</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(php|php3|php4|php5|phpt|phtml|aw|ctp)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(php|php3|php4|php5|phpt|phtml|aw|ctp)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -629,7 +629,7 @@
       <key>fenced_code_block_sql</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(sql|ddl|dml)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(sql|ddl|dml)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -682,7 +682,7 @@
       <key>fenced_code_block_vs_net</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(vb)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(vb)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -735,7 +735,7 @@
       <key>fenced_code_block_xml</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -788,7 +788,7 @@
       <key>fenced_code_block_xsl</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xsl|xslt)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(xsl|xslt)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -841,7 +841,7 @@
       <key>fenced_code_block_yaml</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(yaml|yml)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(yaml|yml)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -894,7 +894,7 @@
       <key>fenced_code_block_dosbatch</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bat|batch)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bat|batch)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -947,7 +947,7 @@
       <key>fenced_code_block_clojure</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(clj|cljs|clojure)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(clj|cljs|clojure)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1000,7 +1000,7 @@
       <key>fenced_code_block_coffee</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(coffee|Cakefile|coffee.erb)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(coffee|Cakefile|coffee.erb)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1053,7 +1053,7 @@
       <key>fenced_code_block_c</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(c|h)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(c|h)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1106,7 +1106,7 @@
       <key>fenced_code_block_cpp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cpp|c\+\+|cxx)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cpp|c\+\+|cxx)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1159,7 +1159,7 @@
       <key>fenced_code_block_diff</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(patch|diff|rej)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(patch|diff|rej)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1212,7 +1212,7 @@
       <key>fenced_code_block_dockerfile</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dockerfile|Dockerfile)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dockerfile|Dockerfile)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1265,7 +1265,7 @@
       <key>fenced_code_block_git_commit</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(COMMIT_EDITMSG|MERGE_MSG)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(COMMIT_EDITMSG|MERGE_MSG)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1318,7 +1318,7 @@
       <key>fenced_code_block_git_rebase</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(git-rebase-todo)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(git-rebase-todo)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1371,7 +1371,7 @@
       <key>fenced_code_block_go</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(go|golang)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(go|golang)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1424,7 +1424,7 @@
       <key>fenced_code_block_groovy</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(groovy|gvy)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(groovy|gvy)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1477,7 +1477,7 @@
       <key>fenced_code_block_pug</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jade|pug)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1530,7 +1530,7 @@
       <key>fenced_code_block_js</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(js|jsx|javascript|es6|mjs|cjs|dataviewjs|\{\.js.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(js|jsx|javascript|es6|mjs|cjs|dataviewjs|\{\.js.+?\})((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1583,7 +1583,7 @@
       <key>fenced_code_block_js_regexp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(regexp)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(regexp)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1636,7 +1636,7 @@
       <key>fenced_code_block_json</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(json|json5|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(json|json5|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1689,7 +1689,7 @@
       <key>fenced_code_block_jsonc</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(jsonc)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1742,7 +1742,7 @@
       <key>fenced_code_block_less</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(less)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(less)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1795,7 +1795,7 @@
       <key>fenced_code_block_objc</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(objectivec|objective-c|mm|objc|obj-c|m|h)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(objectivec|objective-c|mm|objc|obj-c|m|h)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1848,7 +1848,7 @@
       <key>fenced_code_block_swift</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(swift)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(swift)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1901,7 +1901,7 @@
       <key>fenced_code_block_scss</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scss)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scss)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -1954,7 +1954,7 @@
       <key>fenced_code_block_perl6</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl6|p6|pl6|pm6|nqp)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(perl6|p6|pl6|pm6|nqp)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2007,7 +2007,7 @@
       <key>fenced_code_block_powershell</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(powershell|ps1|psm1|psd1)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(powershell|ps1|psm1|psd1)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2060,7 +2060,7 @@
       <key>fenced_code_block_python</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|\{\.python.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi|\{\.python.+?\})((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2113,7 +2113,7 @@
       <key>fenced_code_block_julia</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(julia|\{\.julia.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(julia|\{\.julia.+?\})((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2166,7 +2166,7 @@
       <key>fenced_code_block_regexp_python</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(re)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(re)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2219,7 +2219,7 @@
       <key>fenced_code_block_rust</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(rust|rs|\{\.rust.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(rust|rs|\{\.rust.+?\})((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2272,7 +2272,7 @@
       <key>fenced_code_block_scala</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scala|sbt)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(scala|sbt)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2325,7 +2325,7 @@
       <key>fenced_code_block_shell</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init|\{\.bash.+?\})((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init|\{\.bash.+?\})((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2378,7 +2378,7 @@
       <key>fenced_code_block_ts</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(typescript|ts)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(typescript|ts)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2431,7 +2431,7 @@
       <key>fenced_code_block_tsx</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(tsx)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(tsx)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2484,7 +2484,7 @@
       <key>fenced_code_block_csharp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cs|csharp|c#)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(cs|csharp|c#)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2537,7 +2537,7 @@
       <key>fenced_code_block_fsharp</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(fs|fsharp|f#)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(fs|fsharp|f#)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2590,7 +2590,7 @@
       <key>fenced_code_block_dart</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dart)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(dart)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2643,7 +2643,7 @@
       <key>fenced_code_block_handlebars</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(handlebars|hbs)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(handlebars|hbs)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2696,7 +2696,7 @@
       <key>fenced_code_block_markdown</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(markdown|md)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(markdown|md)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2749,7 +2749,7 @@
       <key>fenced_code_block_log</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(log)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(log)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2802,7 +2802,7 @@
       <key>fenced_code_block_erlang</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(erlang)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(erlang)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2855,7 +2855,7 @@
       <key>fenced_code_block_elixir</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(elixir)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(elixir)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2908,7 +2908,7 @@
       <key>fenced_code_block_latex</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(latex|tex)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -2961,7 +2961,7 @@
       <key>fenced_code_block_bibtex</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?)(?:(?!`{3}|~{3}).)*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(bibtex)((\s+|:|,|\{|\?)[^`]*)?$)</string>
         <key>name</key>
         <string>markup.fenced_code.block.markdown</string>
         <key>end</key>
@@ -3244,7 +3244,7 @@
       <key>fenced_code_block_unknown</key>
       <dict>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?=([^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?=([^`]*)?$)</string>
         <key>beginCaptures</key>
         <dict>
           <key>3</key>

--- a/test/colorize-fixtures/issue-126.md
+++ b/test/colorize-fixtures/issue-126.md
@@ -1,0 +1,9 @@
+```sh
+cd ~/$foo
+```
+
+```sh {higlight="content:~/$foo"}
+cd ~/$foo
+```
+
+```foo```

--- a/test/colorize-results/issue-126_md.json
+++ b/test/colorize-results/issue-126_md.json
@@ -1,0 +1,266 @@
+[
+	{
+		"c": "```",
+		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "sh",
+		"t": "text.html.markdown markup.fenced_code.block.markdown fenced_code.block.language.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "cd",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript support.function.builtin.shell",
+		"r": {
+			"dark_plus": "support.function: #DCDCAA",
+			"light_plus": "support.function: #795E26",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "support.function: #DCDCAA",
+			"hc_light": "support.function: #5E2CBC"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript",
+		"r": {
+			"dark_plus": "meta.embedded: #D4D4D4",
+			"light_plus": "meta.embedded: #000000",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "meta.embedded: #FFFFFF",
+			"hc_light": "meta.embedded: #292929"
+		}
+	},
+	{
+		"c": "~",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript keyword.operator.tilde.shell",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4",
+			"hc_light": "keyword.operator: #000000"
+		}
+	},
+	{
+		"c": "/",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript",
+		"r": {
+			"dark_plus": "meta.embedded: #D4D4D4",
+			"light_plus": "meta.embedded: #000000",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "meta.embedded: #FFFFFF",
+			"hc_light": "meta.embedded: #292929"
+		}
+	},
+	{
+		"c": "$",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript variable.other.normal.shell punctuation.definition.variable.shell",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE",
+			"hc_light": "variable: #001080"
+		}
+	},
+	{
+		"c": "foo",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript variable.other.normal.shell",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE",
+			"hc_light": "variable: #001080"
+		}
+	},
+	{
+		"c": "```",
+		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "```",
+		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "sh",
+		"t": "text.html.markdown markup.fenced_code.block.markdown fenced_code.block.language.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": " {higlight=\"content:~/$foo\"}",
+		"t": "text.html.markdown markup.fenced_code.block.markdown fenced_code.block.language.attributes.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "cd",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript support.function.builtin.shell",
+		"r": {
+			"dark_plus": "support.function: #DCDCAA",
+			"light_plus": "support.function: #795E26",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "support.function: #DCDCAA",
+			"hc_light": "support.function: #5E2CBC"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript",
+		"r": {
+			"dark_plus": "meta.embedded: #D4D4D4",
+			"light_plus": "meta.embedded: #000000",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "meta.embedded: #FFFFFF",
+			"hc_light": "meta.embedded: #292929"
+		}
+	},
+	{
+		"c": "~",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript keyword.operator.tilde.shell",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4",
+			"hc_light": "keyword.operator: #000000"
+		}
+	},
+	{
+		"c": "/",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript",
+		"r": {
+			"dark_plus": "meta.embedded: #D4D4D4",
+			"light_plus": "meta.embedded: #000000",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "meta.embedded: #FFFFFF",
+			"hc_light": "meta.embedded: #292929"
+		}
+	},
+	{
+		"c": "$",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript variable.other.normal.shell punctuation.definition.variable.shell",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE",
+			"hc_light": "variable: #001080"
+		}
+	},
+	{
+		"c": "foo",
+		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.shellscript variable.other.normal.shell",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "meta.embedded: #D4D4D4",
+			"light_vs": "meta.embedded: #000000",
+			"hc_black": "variable: #9CDCFE",
+			"hc_light": "variable: #001080"
+		}
+	},
+	{
+		"c": "```",
+		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "default: #292929"
+		}
+	},
+	{
+		"c": "```",
+		"t": "text.html.markdown meta.paragraph.markdown markup.inline.raw.string.markdown punctuation.definition.raw.markdown",
+		"r": {
+			"dark_plus": "markup.inline.raw: #CE9178",
+			"light_plus": "markup.inline.raw: #800000",
+			"dark_vs": "markup.inline.raw: #CE9178",
+			"light_vs": "markup.inline.raw: #800000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "markup.inline.raw: #0F4A85"
+		}
+	},
+	{
+		"c": "foo",
+		"t": "text.html.markdown meta.paragraph.markdown markup.inline.raw.string.markdown",
+		"r": {
+			"dark_plus": "markup.inline.raw: #CE9178",
+			"light_plus": "markup.inline.raw: #800000",
+			"dark_vs": "markup.inline.raw: #CE9178",
+			"light_vs": "markup.inline.raw: #800000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "markup.inline.raw: #0F4A85"
+		}
+	},
+	{
+		"c": "```",
+		"t": "text.html.markdown meta.paragraph.markdown markup.inline.raw.string.markdown punctuation.definition.raw.markdown",
+		"r": {
+			"dark_plus": "markup.inline.raw: #CE9178",
+			"light_plus": "markup.inline.raw: #800000",
+			"dark_vs": "markup.inline.raw: #CE9178",
+			"light_vs": "markup.inline.raw: #800000",
+			"hc_black": "default: #FFFFFF",
+			"hc_light": "markup.inline.raw: #0F4A85"
+		}
+	}
+]

--- a/test/colorize-results/issue-4_md.json
+++ b/test/colorize-results/issue-4_md.json
@@ -15,11 +15,11 @@
 		"c": "![",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.link.description.begin.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -39,11 +39,11 @@
 		"c": "]",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.link.description.end.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -51,11 +51,11 @@
 		"c": "(",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -63,11 +63,11 @@
 		"c": "path",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown meta.image.inline.markdown markup.underline.link.image.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -75,11 +75,11 @@
 		"c": ")",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -147,11 +147,11 @@
 		"c": "![",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.link.description.begin.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -171,11 +171,11 @@
 		"c": "]",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.link.description.end.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -183,11 +183,11 @@
 		"c": "(",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -195,11 +195,11 @@
 		"c": "path",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown meta.image.inline.markdown markup.underline.link.image.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},
@@ -207,11 +207,11 @@
 		"c": ")",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown meta.image.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178",
+			"dark_plus": "string meta.image.inline.markdown: #D4D4D4",
+			"light_plus": "string meta.image.inline.markdown: #000000",
+			"dark_vs": "string meta.image.inline.markdown: #D4D4D4",
+			"light_vs": "string meta.image.inline.markdown: #000000",
+			"hc_black": "string meta.image.inline.markdown: #FFFFFF",
 			"hc_light": "string: #0F4A85"
 		}
 	},

--- a/test/colorize-results/issue-53_md.json
+++ b/test/colorize-results/issue-53_md.json
@@ -40,9 +40,9 @@
 		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.orientation.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -196,9 +196,9 @@
 		"t": "text.html.markdown meta.tag.other.unrecognized.html.derivative meta.attribute.unrecognized.greetingText.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/test/colorize-results/issue-9_md.json
+++ b/test/colorize-results/issue-9_md.json
@@ -364,9 +364,9 @@
 		"t": "text.html.markdown markup.fenced_code.block.markdown meta.embedded.block.php meta.tag.metadata.doctype.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}

--- a/test/colorize-results/test_md.json
+++ b/test/colorize-results/test_md.json
@@ -424,9 +424,9 @@
 		"t": "text.html.markdown meta.tag.structure.div.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -496,9 +496,9 @@
 		"t": "text.html.markdown meta.tag.structure.div.start.html meta.attribute.unrecognized.markdown.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -724,9 +724,9 @@
 		"t": "text.html.markdown meta.embedded.block.html meta.tag.metadata.script.start.html meta.attribute.type.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -916,9 +916,9 @@
 		"t": "text.html.markdown meta.tag.inline.b.start.html meta.attribute.class.html entity.other.attribute-name.html",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
-			"light_plus": "entity.other.attribute-name: #FF0000",
+			"light_plus": "entity.other.attribute-name: #E50000",
 			"dark_vs": "entity.other.attribute-name: #9CDCFE",
-			"light_vs": "entity.other.attribute-name: #FF0000",
+			"light_vs": "entity.other.attribute-name: #E50000",
 			"hc_black": "entity.other.attribute-name: #9CDCFE",
 			"hc_light": "entity.other.attribute-name: #264F78"
 		}
@@ -1156,9 +1156,9 @@
 		"t": "text.html.markdown meta.embedded.block.html source.css meta.property-list.css meta.property-name.css support.type.property-name.css",
 		"r": {
 			"dark_plus": "support.type.property-name: #9CDCFE",
-			"light_plus": "support.type.property-name: #FF0000",
+			"light_plus": "support.type.property-name: #E50000",
 			"dark_vs": "support.type.property-name: #9CDCFE",
-			"light_vs": "support.type.property-name: #FF0000",
+			"light_vs": "support.type.property-name: #E50000",
 			"hc_black": "support.type.property-name: #D4D4D4",
 			"hc_light": "support.type.property-name: #264F78"
 		}


### PR DESCRIPTION
This fixes #126.

Fenced code blocks fail if there is a tilde (or backtick) in the attributes of a fenced codeblock.

For example, the following markdown highlights as expected.

~~~
```sh {higlight="content:/$foo"}
cd ~/$foo
```
~~~

But as soon as you add a tilde to the filepath, syntax highlighting stops working:

~~~
```sh {higlight="content:~/$foo"}
cd ~/$foo
```
~~~
