### PR TITLE
Add support for Twig syntax

### DIFF
--- a/build.js
+++ b/build.js
@@ -65,7 +65,8 @@ const languages = [
 	{ name: 'erlang', language: 'erlang', identifiers: ['erlang'], source: 'source.erlang' },
 	{ name: 'elixir', language: 'elixir', identifiers: ['elixir'], source: 'source.elixir' },
 	{ name: 'latex', language: 'latex', identifiers: ['latex', 'tex'], source: 'text.tex.latex' },
-	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' }
+	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' },
+	{ name: 'twig', language: 'twig', identifiers: ['twig'], source: 'source.twig' },
 ];
 
 const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, additionalContentName) => {

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3011,6 +3011,59 @@
           </dict>
         </array>
       </dict>
+      <key>fenced_code_block_twig</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(twig)((\s+|:|,|\{|\?)[^`]*)?$)</string>
+        <key>name</key>
+        <string>markup.fenced_code.block.markdown</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.markdown</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.attributes.markdown</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.twig</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>source.twig</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
       <key>fenced_code_block</key>
       <dict>
         <key>patterns</key>
@@ -3234,6 +3287,10 @@
           <dict>
             <key>include</key>
             <string>#fenced_code_block_bibtex</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#fenced_code_block_twig</string>
           </dict>
           <dict>
             <key>include</key>


### PR DESCRIPTION
Hey, I would love to have my Twig code blocks highlighted within markdown files. I hope the attached changes are appropriate, otherwise please let me know.