### PR TITLE
Fix `FrontMatter` integration

### DIFF
--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -200,11 +200,20 @@ repository:
       ]{4}|\t)'}
   separator: {match: '(^|\G)[ ]{0,3}([\*\-\_])([ ]{0,2}\2){2,}[ \t]*$\n?', name: meta.separator.markdown}
   frontMatter:
-    begin: \A-{3}\s*$
-    contentName: meta.embedded.block.frontmatter
+    begin: \A(?=(-{3,}))
+    end: ^ {,3}\1-*[ \t]*$|^[ \t]*\.{3}$
+    applyEndPatternLast: 1
+    endCaptures:
+      0: {name: punctuation.definition.end.frontmatter}
     patterns:
-    - {include: source.yaml}
-    end: (^|\G)-{3}|\.{3}\s*$
+    - begin: \A(-{3,})(.*)$
+      while: ^(?! {,3}\1-*[ \t]*$|[ \t]*\.{3}$)
+      beginCaptures:
+        "1": {name: punctuation.definition.begin.frontmatter}
+        "2": {name: comment.frontmatter}
+      contentName: meta.embedded.block.frontmatter
+      patterns:
+      - {include: source.yaml}
   table:
     name: markup.table.markdown
     begin: (^|\G)(\|)(?=[^|].+\|\s*$)


### PR DESCRIPTION
brings the `FrontMatter` rules into alignment with the [markdown-it-front-matter](https://www.npmjs.com/package/markdown-it-front-matter) package and VSCode's [Markdown Preview](https://github.com/microsoft/vscode/tree/main/extensions/markdown-language-features) feature

prepares for the possible VSCode YAML TextMate grammar update [old grammar](https://github.com/textmate/yaml.tmbundle) => [new grammar](https://github.com/RedCMD/YAML-Syntax-Highlighter)
the new grammar is more eager and breaks out of the current implementation

fixes: https://github.com/microsoft/vscode-markdown-tm-grammar/issues/164
fixes old VSCode issue: [YAML frontmatter hyphens in markdown files have no scope applied](https://github.com/microsoft/vscode/issues/170032)

old:
![image](https://github.com/microsoft/vscode-markdown-tm-grammar/assets/33529441/2d41366f-1738-47e5-87b5-be50c928372a)
new:
![image](https://github.com/microsoft/vscode-markdown-tm-grammar/assets/33529441/8881a7eb-ffea-46a4-8c47-dca2c2513e7c)


![image](https://github.com/microsoft/vscode-markdown-tm-grammar/assets/33529441/1cdf2728-3fb5-44c3-b693-459fb7f1bfd3)
