### PR TITLE
Fix strikethrough with underscores in Markdown syntax (Fixes microsoft#173)

### DIFF
--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -4962,7 +4962,8 @@
           </dict>
         </dict>
         <key>match</key>
-        <string>(?&lt;!\\)(~{2,})((?:[^~]|(?!(?&lt;![~\\])\1(?!~))~)*+)(\1)</string>
+        <string>(?&lt;!\\)(~{2,})(?!(?&lt;=\w~~)_)((?:[^~]|(?!(?&lt;![~\\])\1(?!~))~)*+)(\1)(?!(?&lt;=_\1)\w)</string>
+                
         <key>name</key>
         <string>markup.strikethrough.markdown</string>
       </dict>

--- a/test/colorize-fixtures/issue-173.md
+++ b/test/colorize-fixtures/issue-173.md
@@ -1,0 +1,1 @@
+x~~_deleted~~_x

--- a/test/colorize-results/issue-173_md.json
+++ b/test/colorize-results/issue-173_md.json
@@ -1,0 +1,16 @@
+[
+	{
+		"c": "x~~_deleted~~_x",
+		"t": "text.html.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF",
+			"dark_modern": "default: #CCCCCC",
+			"hc_light": "default: #292929",
+			"light_modern": "default: #3B3B3B"
+		}
+	}
+]


### PR DESCRIPTION
This pull request updates the regex to prevent strikethrough from matching when: -The pattern 'string~~_' or '_~~string' is present fixing issue (https://github.com/microsoft/vscode-markdown-tm-grammar/issues/173).

This happened when patterns like "x~~_deleted~~_x" would strikethrough in editing but not in preview

To test that the code has the expected behaviour a test was added to colorize-tests.