### PR TITLE
Add support for SAP ABAP syntax

### DIFF
--- a/build.js
+++ b/build.js
@@ -67,6 +67,7 @@ const languages = [
 	{ name: 'latex', language: 'latex', identifiers: ['latex', 'tex'], source: 'text.tex.latex' },
 	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' },
 	{ name: 'twig', language: 'twig', identifiers: ['twig'], source: 'source.twig' },
+	{ name: 'abap', language: 'abap', identifiers: ['abap'], source: 'source.abap' }
 ];
 
 const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, additionalContentName) => {

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3068,6 +3068,59 @@
           </dict>
         </array>
       </dict>
+      <key>fenced_code_block_abap</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(abap)((\s+|:|,|\{|\?)[^`]*)?$)</string>
+        <key>name</key>
+        <string>markup.fenced_code.block.markdown</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.markdown</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.attributes.markdown</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.abap</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>source.abap</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
       <key>fenced_code_block</key>
       <dict>
         <key>patterns</key>
@@ -3295,6 +3348,10 @@
           <dict>
             <key>include</key>
             <string>#fenced_code_block_twig</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#fenced_code_block_abap</string>
           </dict>
           <dict>
             <key>include</key>


### PR DESCRIPTION
This would enable syntax highlighting for the SAP ABAP language in markdown code blocks.