### PR TITLE
Add restructuredtext support in markdown code block

### DIFF
--- a/build.js
+++ b/build.js
@@ -67,6 +67,7 @@ const languages = [
 	{ name: 'latex', language: 'latex', identifiers: ['latex', 'tex'], source: 'text.tex.latex' },
 	{ name: 'bibtex', language: 'bibtex', identifiers: ['bibtex'], source: 'text.bibtex' },
 	{ name: 'twig', language: 'twig', identifiers: ['twig'], source: 'source.twig' },
+	{ name: 'restructuredtext', language: 'restructuredtext', identifiers: ['restructuredtext', 'rst'], source: 'source.rst' },
 ];
 
 const fencedCodeBlockDefinition = (name, identifiers, sourceScope, language, additionalContentName) => {

--- a/markdown.tmLanguage.base.yaml
+++ b/markdown.tmLanguage.base.yaml
@@ -584,7 +584,7 @@ repository:
         - {include: '#link-ref'}
         - {include: '#link-ref-shortcut'}
       '3': {name: punctuation.definition.strikethrough.markdown}
-    match: (?<!\\)(~{2,})((?:[^~]|(?!(?<![~\\])\1(?!~))~)*+)(\1)
+    match: (?<!\\)(~{2,})(?!(?<=\w~~)_)((?:[^~]|(?!(?<![~\\])\1(?!~))~)*+)(\1)(?!(?<=_\1)\w)
     name: markup.strikethrough.markdown
 scopeName: text.html.markdown
 uuid: 0A1D9874-B448-11D9-BD50-000D93B6E43C

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -3068,6 +3068,59 @@
           </dict>
         </array>
       </dict>
+      <key>fenced_code_block_restructuredtext</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(restructuredtext|rst)((\s+|:|,|\{|\?)[^`]*)?$)</string>
+        <key>name</key>
+        <string>markup.fenced_code.block.markdown</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.markdown</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.attributes.markdown</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.restructuredtext</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>source.rst</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
       <key>fenced_code_block</key>
       <dict>
         <key>patterns</key>
@@ -3295,6 +3348,10 @@
           <dict>
             <key>include</key>
             <string>#fenced_code_block_twig</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#fenced_code_block_restructuredtext</string>
           </dict>
           <dict>
             <key>include</key>

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -5020,7 +5020,6 @@
         </dict>
         <key>match</key>
         <string>(?&lt;!\\)(~{2,})(?!(?&lt;=\w~~)_)((?:[^~]|(?!(?&lt;![~\\])\1(?!~))~)*+)(\1)(?!(?&lt;=_\1)\w)</string>
-                
         <key>name</key>
         <string>markup.strikethrough.markdown</string>
       </dict>


### PR DESCRIPTION
https://github.com/microsoft/vscode/pull/144680 added built-in support for reStructuredText grammar. This MR extends the usage for within markdown code block by using either restructuredtext or rst.

Demo with the Launch Extension configuration in the VS Code debugger and run:

<img width="734" height="628" alt="image" src="https://github.com/user-attachments/assets/fb5bd0a6-fca1-4e90-ad7f-dc9f3ccffc9d" />

1. RST definition was added to `build.js`
2. #174 was added to `markdown.tmLanguage.base.yaml`
3. `npm run build` was run to fill `syntaxes/markdown.tmLanguage`