### PR TITLE
support hsml

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -42,6 +42,7 @@ const languages: Language[] = [
     { name: 'go', language: 'go', identifiers: ['go', 'golang'], source: 'source.go' },
     { name: 'groovy', language: 'groovy', identifiers: ['groovy', 'gvy'], source: 'source.groovy' },
     { name: 'pug', language: 'pug', identifiers: ['jade', 'pug'], source: 'text.pug' },
+    { name: 'hsml', language: 'hsml', identifiers: ['hsml'], source: 'text.hsml' },
 
     { name: 'ignore', language: 'ignore', identifiers: ['gitignore', 'ignore'], source: 'source.ignore' },
     { name: 'js', language: 'javascript', identifiers: ['js', 'jsx', 'javascript', 'es6', 'mjs', 'cjs', 'dataviewjs', '\\{\\.js.+?\\}'], source: 'source.js' },

--- a/syntaxes/markdown.tmLanguage
+++ b/syntaxes/markdown.tmLanguage
@@ -1531,6 +1531,59 @@
           </dict>
         </array>
       </dict>
+      <key>fenced_code_block_hsml</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\s*(?i:(hsml)((\s+|:|,|\{|\?)[^`]*)?$)</string>
+        <key>name</key>
+        <string>markup.fenced_code.block.markdown</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.markdown</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>fenced_code.block.language.attributes.markdown</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.markdown</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.hsml</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>text.hsml</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
       <key>fenced_code_block_ignore</key>
       <dict>
         <key>begin</key>
@@ -3444,6 +3497,10 @@
           <dict>
             <key>include</key>
             <string>#fenced_code_block_pug</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#fenced_code_block_hsml</string>
           </dict>
           <dict>
             <key>include</key>


### PR DESCRIPTION
I would like to add support for my hsml language (https://github.com/hsml-lab) which is very similar to pug
so this is right now nearly a 99% copy of the pug code, but adopted for hsml
I'm currently trying to bring syntax highlighting for it
Already did some work here: https://github.com/hsml-lab/vscode-hsml/pull/17
but markdown is just pure white right now