### PR TITLE
Add `dosbatch` as an identifier for dosbatch

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -30,7 +30,7 @@ const languages: Language[] = [
     { name: 'xml', language: 'xml', identifiers: ['xml', 'xsd', 'tld', 'jsp', 'pt', 'cpt', 'dtml', 'rss', 'opml'], source: 'text.xml' },
     { name: 'xsl', language: 'xsl', identifiers: ['xsl', 'xslt'], source: 'text.xml.xsl' },
     { name: 'yaml', language: 'yaml', identifiers: ['yaml', 'yml'], source: 'source.yaml' },
-    { name: 'dosbatch', language: 'dosbatch', identifiers: ['bat', 'batch'], source: 'source.batchfile' },
+    { name: 'dosbatch', language: 'dosbatch', identifiers: ['bat', 'batch', 'dosbatch'], source: 'source.batchfile' },
     { name: 'clojure', language: 'clojure', identifiers: ['clj', 'cljs', 'clojure'], source: 'source.clojure' },
     { name: 'coffee', language: 'coffee', identifiers: ['coffee', 'Cakefile', 'coffee.erb'], source: 'source.coffee' },
     { name: 'c', language: 'c', identifiers: ['c', 'h'], source: 'source.c' },


### PR DESCRIPTION
Originating from https://github.com/microsoft/vscode/pull/318757

To summarize quickly, `dosbatch` is a known name, being recognized by GitHub code fences for the Batchfile language.